### PR TITLE
add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.17 AS build-env
+
+RUN apk add --update autoconf automake libtool git make gcc zlib g++
+
+COPY . src/
+
+RUN cd src \
+  && make \
+  && make install
+
+FROM alpine:3.17
+
+COPY --from=build-env /usr/local/bin /usr/local/bin
+
+WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/nostril"]


### PR DESCRIPTION
This allows for running nostril from a docker image instead of having to worry about building it first.
```
docker run --rm aphex3k/nostril:testing --envelope --dm <hex-pub> --sec <hex-priv> --content "test" | websocat wss://relay.damus.io
```