### PR TITLE
fix: compiler warning base64_decode_tail_using_maps

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -143,7 +143,7 @@ ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3]
 }
 
 
-ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char *dest,
 				  const char * src, const size_t srclen)
 {
 	char longsrc[4];


### PR DESCRIPTION
Fixed the following compiler warning:

```
ase64.c:146:71: warning: argument 2 of type ‘char[3]’ with mismatched bound [-Warray-parameter=]
  146 | ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
      |                                                                  ~~~~~^~~~~~~
In file included from base64.c:2:
base64.h:119:72: note: previously declared as ‘char *’
  119 | ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char *dest,
      |                                                                  ~~~~~~^~~~
```