### PR TITLE
fix: redefinition

### DIFF
--- a/endian.h
+++ b/endian.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 
 #include "config.h"
-#include "cursor.h"
 
 /**
  * BSWAP_16 - reverse bytes in a constant uint16_t value.


### PR DESCRIPTION
```
Reinitializing submodules deps/secp256k1 deps/
  libsodium ...
  Synchronizing submodule url for 'deps/libsodium'
  Synchronizing submodule url for 'deps/secp256k1'
  Submodule path 'deps/libsodium': checked out
  '9511c982fb1d046470a8b42aa36556cdb7da15de'
  Submodule path 'deps/secp256k1': checked out
  '694ce8fb2d1fd8a3d641d7c33705691d41a2a860'
  cc sha256.c
  In file included from sha256.c:10:
  ./endian.h:73:24: error: redefinition of 'bswap_16'
     73 | static inline uint16_t bswap_16(uint16_t val)
        |                        ^
  ./cursor.h:267:24: note: previous definition is here
    267 | static inline uint16_t bswap_16(uint16_t val)
        |                        ^
  1 error generated.
  make: *** [Makefile:62: sha256.o] Error 1
```